### PR TITLE
[BUG] .DS_Store 파일 .gitignore에 추가

### DIFF
--- a/Replendar/.gitignore
+++ b/Replendar/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.DS_Store


### PR DESCRIPTION
**.DS_Store (Desktop Services Store)**
: MacOS에서 Finder로 폴더를 볼 때마다 자동으로 생성되는 폴더

→ 노출되면 안 돼서 .gitignore 파일에 추가